### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+*.sca linguist-language=GLSL


### PR DESCRIPTION
Add a .gitattributes to highlight SCA code as if it were GLSL. Not perfect, but i think it makes it more readable